### PR TITLE
feat(authentication): add userId and drop email

### DIFF
--- a/src/AuthenticatedAPIClient/authInterface.js
+++ b/src/AuthenticatedAPIClient/authInterface.js
@@ -35,7 +35,7 @@ export default function applyAuthInterface(httpClient, authConfig) {
     const token = httpClient.getDecodedAccessToken();
     if (token) {
       state.authentication = {
-        email: token.email,
+        userId: token.user_id,
         username: token.preferred_username,
       };
     }

--- a/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
+++ b/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
@@ -19,7 +19,7 @@ const tomorrow = new Date();
 tomorrow.setDate(tomorrow.getDate() + 1);
 
 const jwt = {
-  email: 'test@example.com',
+  user_id: '12345',
   preferred_username: 'test',
 };
 const expiredJwt = Object.assign({ exp: yesterday.getTime() / 1000 }, jwt);
@@ -156,7 +156,9 @@ describe('AuthenticatedAPIClient auth interface', () => {
   it('has method getAuthenticationState that returns authentication state when valid JWT cookie exists', () => {
     mockCookies.get.mockReturnValueOnce(encodedValidJwt);
     const result = client.getAuthenticationState();
-    expect(result.authentication.email).toEqual(validJwt.email);
+    expect(result.authentication.userId).toBeDefined();
+    expect(result.authentication.userId).toEqual(validJwt.user_id);
+    expect(result.authentication.username).toBeDefined();
     expect(result.authentication.username).toEqual(validJwt.preferred_username);
   });
 

--- a/src/PrivateRoute/PrivateRoute.test.jsx
+++ b/src/PrivateRoute/PrivateRoute.test.jsx
@@ -42,7 +42,7 @@ describe('PrivateRoute', () => {
   it('renders private component if authenticated', () => {
     const store = mockStore({
       authentication: {
-        email: 'test@example.com',
+        userId: '12345',
         username: 'test',
       },
     });


### PR DESCRIPTION
The following changes were made to authentication state:
- add userId (LMS user_id).
- remove email.

BREAKING CHANGE: email is no longer available from authentication state.
Use email from the user profile instead.