### PR TITLE
fix(saving): removing code related to saving actions

### DIFF
--- a/src/actions/userAccount.js
+++ b/src/actions/userAccount.js
@@ -1,10 +1,6 @@
 const FETCH_USER_ACCOUNT_BEGIN = 'FETCH_USER_ACCOUNT_BEGIN';
 const FETCH_USER_ACCOUNT_SUCCESS = 'FETCH_USER_ACCOUNT_SUCCESS';
 const FETCH_USER_ACCOUNT_FAILURE = 'FETCH_USER_ACCOUNT_FAILURE';
-const SAVE_USER_ACCOUNT_BEGIN = 'SAVE_USER_ACCOUNT_BEGIN';
-const SAVE_USER_ACCOUNT_SUCCESS = 'SAVE_USER_ACCOUNT_SUCCESS';
-const SAVE_USER_ACCOUNT_FAILURE = 'SAVE_USER_ACCOUNT_FAILURE';
-
 
 const fetchUserAccountBegin = () => ({
   type: FETCH_USER_ACCOUNT_BEGIN,
@@ -17,20 +13,6 @@ const fetchUserAccountSuccess = userAccount => ({
 
 const fetchUserAccountFailure = error => ({
   type: FETCH_USER_ACCOUNT_FAILURE,
-  payload: { error },
-});
-
-const saveUserAccountBegin = () => ({
-  type: SAVE_USER_ACCOUNT_BEGIN,
-});
-
-const saveUserAccountSuccess = userAccount => ({
-  type: SAVE_USER_ACCOUNT_SUCCESS,
-  payload: { userAccount },
-});
-
-const saveUserAccountFailure = error => ({
-  type: SAVE_USER_ACCOUNT_FAILURE,
   payload: { error },
 });
 
@@ -47,32 +29,12 @@ const fetchUserAccount = (userAccountApiService, username) => (
   }
 );
 
-const saveUserAccount = (userAccountApiService, username, userAccountState) => (
-  (dispatch) => {
-    dispatch(saveUserAccountBegin());
-    return userAccountApiService.saveUserAccount(username, userAccountState)
-      .then((userAccount) => {
-        dispatch(saveUserAccountSuccess(userAccount));
-      })
-      .catch((error) => {
-        dispatch(saveUserAccountFailure(error));
-      });
-  }
-);
-
 export {
   FETCH_USER_ACCOUNT_BEGIN,
   FETCH_USER_ACCOUNT_SUCCESS,
   FETCH_USER_ACCOUNT_FAILURE,
-  SAVE_USER_ACCOUNT_BEGIN,
-  SAVE_USER_ACCOUNT_SUCCESS,
-  SAVE_USER_ACCOUNT_FAILURE,
   fetchUserAccountBegin,
   fetchUserAccountSuccess,
   fetchUserAccountFailure,
   fetchUserAccount,
-  saveUserAccountBegin,
-  saveUserAccountSuccess,
-  saveUserAccountFailure,
-  saveUserAccount,
 };

--- a/src/actions/userAccount.test.js
+++ b/src/actions/userAccount.test.js
@@ -10,13 +10,6 @@ import {
   fetchUserAccountSuccess,
   fetchUserAccountFailure,
   fetchUserAccount,
-  SAVE_USER_ACCOUNT_BEGIN,
-  SAVE_USER_ACCOUNT_SUCCESS,
-  SAVE_USER_ACCOUNT_FAILURE,
-  saveUserAccountBegin,
-  saveUserAccountSuccess,
-  saveUserAccountFailure,
-  saveUserAccount,
 } from './userAccount';
 
 const mockStore = configureMockStore([thunk]);
@@ -103,92 +96,6 @@ describe('FETCH userAccount actions', () => {
 
     const userAccountApiService = new UserAccountApiService();
     return store.dispatch(fetchUserAccount(userAccountApiService, username)).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-});
-
-describe('SAVE userAccount actions', () => {
-  it('should create an action to begin user account save', () => {
-    const expectedAction = {
-      type: SAVE_USER_ACCOUNT_BEGIN,
-    };
-    expect(saveUserAccountBegin()).toEqual(expectedAction);
-  });
-
-  it('should create an action to signal user account save success', () => {
-    const userAccount = {
-      username: 'test',
-    };
-    const expectedAction = {
-      type: SAVE_USER_ACCOUNT_SUCCESS,
-      payload: { userAccount },
-    };
-    expect(saveUserAccountSuccess(userAccount)).toEqual(expectedAction);
-  });
-
-  it('should create an action to signal user account save failure', () => {
-    const error = 'Test failure';
-    const expectedAction = {
-      type: SAVE_USER_ACCOUNT_FAILURE,
-      payload: { error },
-    };
-    expect(saveUserAccountFailure(error)).toEqual(expectedAction);
-  });
-
-  it('creates SAVE_USER_ACCOUNT_SUCCESS when saving user account has been done', () => {
-    const username = 'test-user';
-    UserAccountApiService.mockImplementation(() => ({
-      saveUserAccount: user => (
-        new Promise((resolve) => {
-          resolve({ username: user });
-        })
-      ),
-    }));
-
-    const expectedActions = [
-      { type: SAVE_USER_ACCOUNT_BEGIN },
-      {
-        type: SAVE_USER_ACCOUNT_SUCCESS,
-        payload: {
-          userAccount: {
-            username,
-          },
-        },
-      },
-    ];
-    const store = mockStore({ userAccount: {} });
-
-    const userAccountApiService = new UserAccountApiService();
-    return store.dispatch(saveUserAccount(userAccountApiService, username)).then(() => {
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-
-  it('creates SAVE_USER_ACCOUNT_FAILURE when saving user account has failed', () => {
-    const username = 'test-user';
-    const error = 'test-error';
-    UserAccountApiService.mockImplementation(() => ({
-      saveUserAccount: () => (
-        new Promise((resolve, reject) => {
-          reject(error);
-        })
-      ),
-    }));
-
-    const expectedActions = [
-      { type: SAVE_USER_ACCOUNT_BEGIN },
-      {
-        type: SAVE_USER_ACCOUNT_FAILURE,
-        payload: {
-          error: 'test-error',
-        },
-      },
-    ];
-    const store = mockStore({ userAccount: {} });
-
-    const userAccountApiService = new UserAccountApiService();
-    return store.dispatch(saveUserAccount(userAccountApiService, username)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { fetchUserAccount, saveUserAccount } from './actions/userAccount';
+import { fetchUserAccount, fetchUserAccountSuccess } from './actions/userAccount';
 import getAuthenticatedAPIClient from './AuthenticatedAPIClient';
 import PrivateRoute from './PrivateRoute';
 import userAccount from './reducers/userAccount';
@@ -6,9 +6,9 @@ import UserAccountApiService from './services/UserAccountApiService';
 
 export {
   fetchUserAccount,
+  fetchUserAccountSuccess,
   getAuthenticatedAPIClient,
   PrivateRoute,
-  saveUserAccount,
   userAccount,
   UserAccountApiService,
 };

--- a/src/reducers/userAccount.js
+++ b/src/reducers/userAccount.js
@@ -2,9 +2,6 @@ import {
   FETCH_USER_ACCOUNT_BEGIN,
   FETCH_USER_ACCOUNT_SUCCESS,
   FETCH_USER_ACCOUNT_FAILURE,
-  SAVE_USER_ACCOUNT_BEGIN,
-  SAVE_USER_ACCOUNT_SUCCESS,
-  SAVE_USER_ACCOUNT_FAILURE,
 } from '../actions/userAccount';
 
 const initialState = {
@@ -38,24 +35,6 @@ const userAccount = (state = initialState, action) => {
         ...action.payload.userAccount,
       };
     case FETCH_USER_ACCOUNT_FAILURE:
-      return {
-        ...state,
-        loading: false,
-        error: action.payload.error,
-      };
-    case SAVE_USER_ACCOUNT_BEGIN:
-      return {
-        ...state,
-        loading: true,
-        error: null,
-      };
-    case SAVE_USER_ACCOUNT_SUCCESS:
-      return {
-        ...state,
-        loading: false,
-        ...action.payload.userAccount,
-      };
-    case SAVE_USER_ACCOUNT_FAILURE:
       return {
         ...state,
         loading: false,

--- a/src/reducers/userAccount.test.js
+++ b/src/reducers/userAccount.test.js
@@ -2,9 +2,6 @@ import {
   FETCH_USER_ACCOUNT_BEGIN,
   FETCH_USER_ACCOUNT_SUCCESS,
   FETCH_USER_ACCOUNT_FAILURE,
-  SAVE_USER_ACCOUNT_BEGIN,
-  SAVE_USER_ACCOUNT_SUCCESS,
-  SAVE_USER_ACCOUNT_FAILURE,
 } from '../actions/userAccount';
 import reducer from './userAccount';
 
@@ -54,40 +51,6 @@ describe('userAccount reducer', () => {
     const error = 'Test failure';
     expect(reducer({}, {
       type: FETCH_USER_ACCOUNT_FAILURE,
-      payload: { error },
-    })).toEqual({
-      loading: false,
-      error,
-    });
-  });
-
-  it('should handle SAVE_USER_ACCOUNT_BEGIN', () => {
-    expect(reducer({}, {
-      type: SAVE_USER_ACCOUNT_BEGIN,
-    })).toEqual({
-      loading: true,
-      error: null,
-    });
-  });
-
-  it('should handle SAVE_USER_ACCOUNT_SUCCESS', () => {
-    const userAccount = {
-      email: 'test',
-      username: 'test',
-    };
-    expect(reducer({}, {
-      type: SAVE_USER_ACCOUNT_SUCCESS,
-      payload: { userAccount },
-    })).toEqual({
-      loading: false,
-      ...userAccount,
-    });
-  });
-
-  it('should handle SAVE_USER_ACCOUNT_FAILURE', () => {
-    const error = 'Test failure';
-    expect(reducer({}, {
-      type: SAVE_USER_ACCOUNT_FAILURE,
       payload: { error },
     })).toEqual({
       loading: false,


### PR DESCRIPTION
The profile app has its own reducer for managing its internal state, separate from the userAccount reducer provided by this repository.  Therefore, the actions and tests related to that data aren't necessary here anymore (they're not related to 'auth').

Meanwhile, we're leaving the API calls here for the time being so that they can all live in one place and won't drift apart.  Whether they ultimately belong in this repo or in a `frontend-api`-style repo is being deferred.  

This PR also exports the `fetchUserAccountSuccess` action as it has uses outside this repo.  it can be used to emulate a fetch with data from another API, for instance (such as the saveUserAccount API).  

Tests that have been removed from this repo are being added to https://github.com/edx/frontend-app-profile