### PR TITLE
refactor(tests): make tests more resilient

### DIFF
--- a/src/services/UserAccountApiService.test.jsx
+++ b/src/services/UserAccountApiService.test.jsx
@@ -21,7 +21,8 @@ describe('UserAccountApiService.getUserAccount', () => {
     axiosMock.onGet(`${process.env.BASE_URL}/api/user/v1/accounts/${username}`)
       .replyOnce(200, userAccount);
 
-    userAccountApiService.getUserAccount(username)
+    expect.assertions(1);
+    return userAccountApiService.getUserAccount(username)
       .then((result) => {
         expect(result).toEqual(camelcaseKeys(userAccount, { deep: true }));
       });
@@ -30,7 +31,8 @@ describe('UserAccountApiService.getUserAccount', () => {
   it('returns error when unsuccessful', () => {
     axiosMock.onGet(`${process.env.BASE_URL}/api/user/v1/accounts/${username}`).networkError();
 
-    userAccountApiService.getUserAccount(username)
+    expect.assertions(1);
+    return userAccountApiService.getUserAccount(username)
       .catch((error) => {
         expect(error).toEqual(new Error('Network Error'));
       });
@@ -42,7 +44,9 @@ describe('UserAccountApiService.saveUserAccount', () => {
     axiosMock.onPatch(`${process.env.BASE_URL}/api/user/v1/accounts/${username}`)
       .replyOnce(200, userAccount);
 
-    userAccountApiService.saveUserAccount(username, camelcaseKeys(userAccount, { deep: true }))
+    expect.assertions(1);
+    return userAccountApiService
+      .saveUserAccount(username, camelcaseKeys(userAccount, { deep: true }))
       .then((result) => {
         expect(result).toEqual(camelcaseKeys(userAccount, { deep: true }));
       });
@@ -51,7 +55,9 @@ describe('UserAccountApiService.saveUserAccount', () => {
   it('returns error when unsuccessful', () => {
     axiosMock.onPatch(`${process.env.BASE_URL}/api/user/v1/accounts/${username}`).networkError();
 
-    userAccountApiService.saveUserAccount(username, camelcaseKeys(userAccount, { deep: true }))
+    expect.assertions(1);
+    return userAccountApiService
+      .saveUserAccount(username, camelcaseKeys(userAccount, { deep: true }))
       .catch((error) => {
         expect(error).toEqual(new Error('Network Error'));
       });
@@ -63,7 +69,8 @@ describe('UserAccountApiService.saveUserProfilePhoto', () => {
     axiosMock.onPost(`${process.env.BASE_URL}/api/user/v1/accounts/${username}/image`)
       .replyOnce(204);
 
-    userAccountApiService.saveUserProfilePhoto(username)
+    expect.assertions(1);
+    return userAccountApiService.saveUserProfilePhoto(username)
       .then((response) => {
         expect(response.status).toEqual(204);
       });
@@ -75,7 +82,8 @@ describe('UserAccountApiService.deleteUserProfilePhoto', () => {
     axiosMock.onDelete(`${process.env.BASE_URL}/api/user/v1/accounts/${username}/image`)
       .replyOnce(204);
 
-    userAccountApiService.deleteUserProfilePhoto(username)
+    expect.assertions(1);
+    return userAccountApiService.deleteUserProfilePhoto(username)
       .then((response) => {
         expect(response.status).toEqual(204);
       });


### PR DESCRIPTION
@douglashall: I was using your tests to help me write mine.  Unfortunately, I still can't get mine to work. :( 
However, I was able to find a couple of issues with these tests.  The functionality was good, but the problem is they wouldn't fail if there was a problem.

The two issues with each test:

1. You need `expect.assertions(1)` to ensure that the assertion was tested in the first place.
2. You need to return the promise in order to get the assertions you did have to fail the test. For example, if you check out master and change a `204` to `205`, you'll see log output, but the tests still pass.