### PR TITLE
feat(reducers): add a loaded flag to userAccount

### DIFF
--- a/src/reducers/userAccount.js
+++ b/src/reducers/userAccount.js
@@ -6,6 +6,7 @@ import {
 
 const initialState = {
   loading: false,
+  loaded: false,
   error: null,
   username: null,
   email: null,
@@ -26,18 +27,21 @@ const userAccount = (state = initialState, action) => {
       return {
         ...state,
         loading: true,
+        loaded: false,
         error: null,
       };
     case FETCH_USER_ACCOUNT_SUCCESS:
       return {
         ...state,
         loading: false,
+        loaded: true,
         ...action.payload.userAccount,
       };
     case FETCH_USER_ACCOUNT_FAILURE:
       return {
         ...state,
         loading: false,
+        loaded: false,
         error: action.payload.error,
       };
     default:

--- a/src/reducers/userAccount.test.js
+++ b/src/reducers/userAccount.test.js
@@ -9,6 +9,7 @@ describe('userAccount reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
       loading: false,
+      loaded: false,
       error: null,
       username: null,
       email: null,
@@ -29,6 +30,7 @@ describe('userAccount reducer', () => {
       type: FETCH_USER_ACCOUNT_BEGIN,
     })).toEqual({
       loading: true,
+      loaded: false,
       error: null,
     });
   });
@@ -43,6 +45,7 @@ describe('userAccount reducer', () => {
       payload: { userAccount },
     })).toEqual({
       loading: false,
+      loaded: true,
       ...userAccount,
     });
   });
@@ -54,6 +57,7 @@ describe('userAccount reducer', () => {
       payload: { error },
     })).toEqual({
       loading: false,
+      loaded: false,
       error,
     });
   });


### PR DESCRIPTION
Now consumers can know when loading the user account data is complete.

This PR is blocking one in frontend-app-profile.