### PR TITLE
feat(actions): export more actions for userAccount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,12 @@
-import { fetchUserAccount, fetchUserAccountSuccess } from './actions/userAccount';
+import {
+  fetchUserAccount,
+  fetchUserAccountBegin,
+  fetchUserAccountFailure,
+  fetchUserAccountSuccess,
+  FETCH_USER_ACCOUNT_BEGIN,
+  FETCH_USER_ACCOUNT_FAILURE,
+  FETCH_USER_ACCOUNT_SUCCESS,
+} from './actions/userAccount';
 import getAuthenticatedAPIClient from './AuthenticatedAPIClient';
 import PrivateRoute from './PrivateRoute';
 import userAccount from './reducers/userAccount';
@@ -6,7 +14,12 @@ import UserAccountApiService from './services/UserAccountApiService';
 
 export {
   fetchUserAccount,
+  fetchUserAccountBegin,
+  fetchUserAccountFailure,
   fetchUserAccountSuccess,
+  FETCH_USER_ACCOUNT_BEGIN,
+  FETCH_USER_ACCOUNT_FAILURE,
+  FETCH_USER_ACCOUNT_SUCCESS,
   getAuthenticatedAPIClient,
   PrivateRoute,
   userAccount,


### PR DESCRIPTION
It’s useful in consuming apps to be able to hook into the fetch user account lifecycle.

Specifically, this PR was motivated by needing FETCH_USER_ACCOUNT_FAILURE in the profile app so we know when to redirect to an error page.  We already had fetchUserAccountSuccess, so I thought I might as well just proactively complete the set. 