### PR TITLE
fix: remove error log when redirecting a logged out user to sign in

### DIFF
--- a/src/AuthenticatedAPIClient/axiosConfig.js
+++ b/src/AuthenticatedAPIClient/axiosConfig.js
@@ -78,8 +78,9 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
           queueRequests = false;
           PubSub.publishSync(ACCESS_TOKEN_REFRESH);
         })
-        .catch((error) => {
-          logAPIErrorResponse(error, { errorFunctionName: 'ensureValidJWTCookie' });
+        .catch(() => {
+          // TODO: We should give the client app an opportunity to
+          // take control here before logout/redirect to sign in.
           authenticatedAPIClient.logout();
         });
     }


### PR DESCRIPTION
fixes: https://openedx.atlassian.net/browse/ARCH-687

When we understand a user is not logged in, we will no longer log an error before redirecting them to sign in.

There's a TODO in here that we should give applications and opportunity to prevent the page from logging out and redirecting away from the page. This is related to #25 