### PR TITLE
feat: add callback for handling a token refresh failure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,10 @@ To install frontend-auth into your project:
      refreshAccessTokenEndpoint: process.env.REFRESH_ACCESS_TOKEN_ENDPOINT,
      accessTokenCookieName: process.env.ACCESS_TOKEN_COOKIE_NAME,
      loggingService: NewRelicLoggingService, // could be any concrete logging service
+     // handleRefreshAccessTokenFailure is an optional callback 
+     // to handle failures to refresh an access token (the user is likely logged out).
+     // If no callback is supplied frontend-auth will redirect the user to login.
+     // handleRefreshAccessTokenFailure: error => {},
    });
 
 ``frontend-auth`` provides a ``PrivateRoute`` component which can be used along with ``react-router`` to require authentication for specific routes in your app. Here is an example of defining a route that requires authentication:

--- a/src/AuthenticatedAPIClient/authInterface.js
+++ b/src/AuthenticatedAPIClient/authInterface.js
@@ -12,6 +12,8 @@ export default function applyAuthInterface(httpClient, authConfig) {
   httpClient.loginUrl = authConfig.loginUrl;
   httpClient.logoutUrl = authConfig.logoutUrl;
   httpClient.refreshAccessTokenEndpoint = authConfig.refreshAccessTokenEndpoint;
+  httpClient.handleRefreshAccessTokenFailure = authConfig.handleRefreshAccessTokenFailure;
+
   /**
    * We will not try to refresh an expired access token before
    * making requests to these auth-related URLs.

--- a/src/AuthenticatedAPIClient/axiosConfig.js
+++ b/src/AuthenticatedAPIClient/axiosConfig.js
@@ -78,10 +78,11 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
           queueRequests = false;
           PubSub.publishSync(ACCESS_TOKEN_REFRESH);
         })
-        .catch(() => {
-          // TODO: We should give the client app an opportunity to
-          // take control here before logout/redirect to sign in.
-          authenticatedAPIClient.logout();
+        .catch((error) => {
+          if (!authenticatedAPIClient.handleRefreshAccessTokenFailure
+            || authenticatedAPIClient.handleRefreshAccessTokenFailure(error)) {
+            authenticatedAPIClient.logout();
+          }
         });
     }
 
@@ -94,13 +95,20 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
     });
   }
 
-  // Redirect to the logout page if an unauthorized API response was received.
+  // Log errors and info for unauthorized API responses
   function handleUnauthorizedAPIResponse(error) {
-    const errorStatus = error && error.response && error.response.status;
-    if (errorStatus === 401 || errorStatus === 403) {
+    const response = error && error.response;
+    const errorStatus = response && response.status;
+    const requestUrl = response && response.config && response.config.url;
+    const requestIsTokenRefresh = requestUrl === authenticatedAPIClient.refreshAccessTokenEndpoint;
+
+    if (errorStatus === 401 && !requestIsTokenRefresh) {
       logAPIErrorResponse(error, { errorFunctionName: 'handleUnauthorizedAPIResponse' });
-      authenticatedAPIClient.logout(authenticatedAPIClient.appBaseUrl);
     }
+    if (errorStatus === 403) {
+      logInfo(`Forbidden API response from ${requestUrl}`);
+    }
+
     return Promise.reject(error);
   }
 

--- a/src/AuthenticatedAPIClient/axiosConfig.js
+++ b/src/AuthenticatedAPIClient/axiosConfig.js
@@ -79,6 +79,9 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
           PubSub.publishSync(ACCESS_TOKEN_REFRESH, { success: true });
         })
         .catch((error) => {
+          // If no callback is supplied frontend-auth will (ultimately) redirect the user to login.
+          // The user is redirected to logout to ensure authentication clean-up, which in turn
+          // redirects to login.
           if (authenticatedAPIClient.handleRefreshAccessTokenFailure) {
             authenticatedAPIClient.handleRefreshAccessTokenFailure(error);
           } else {
@@ -108,10 +111,10 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
     const requestUrl = response && response.config && response.config.url;
     const requestIsTokenRefresh = requestUrl === authenticatedAPIClient.refreshAccessTokenEndpoint;
 
-    switch (errorStatus) {
+    switch (errorStatus) { // eslint-disable-line default-case
       case 401:
         if (requestIsTokenRefresh) {
-          logInfo(`Unauthorized token refresh response from ${requestUrl}`);
+          logInfo(`Unauthorized token refresh response from ${requestUrl}. This is expected if the user is not yet logged in.`);
         } else {
           logInfo(`Unauthorized API response from ${requestUrl}`);
         }
@@ -119,7 +122,6 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
       case 403:
         logInfo(`Forbidden API response from ${requestUrl}`);
         break;
-      default:
     }
 
     return Promise.reject(error);

--- a/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
+++ b/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
@@ -128,7 +128,7 @@ function testResponseInterceptorRejection(error, expects) {
   it(`${expects.name} when error=${error}`, () => {
     const client = getAuthenticatedAPIClient(authConfig);
     applyMockAuthInterface(client);
-    client.interceptors.response.handlers[0].rejected(error)
+    return client.interceptors.response.handlers[0].rejected(error)
       .catch(() => {
         expects(client);
       });
@@ -310,6 +310,46 @@ describe('AuthenticatedAPIClient ensureValidJWTCookie request interceptor', () =
         expect(rejection).toBe(error);
       });
   });
+
+  it('redirects if a login refresh fails', () => {
+    const client = getAuthenticatedAPIClient({
+      ...authConfig,
+      // handleRefreshAccessTokenFailure: jest.fn(),
+    });
+    const rejectRefreshAccessToken = true;
+    applyMockAuthInterface(client, rejectRefreshAccessToken);
+    client.isAuthUrl.mockReturnValue(true);
+    client.getDecodedAccessToken.mockReturnValue({});
+    client.isAccessTokenExpired.mockReturnValue(true);
+    // eslint-disable-next-line no-underscore-dangle
+    axiosConfig.__Rewire__('queueRequests', false);
+    const failedResult = client.interceptors.request.handlers[0].fulfilled({});
+
+    failedResult.catch(() => {
+      expect(client.logout).toHaveBeenCalled();
+    });
+  });
+
+  it('does not redirect if a login refresh failure handler is supplied', () => {
+    const client = getAuthenticatedAPIClient({
+      ...authConfig,
+      handleRefreshAccessTokenFailure: jest.fn(),
+    });
+    const rejectRefreshAccessToken = true;
+    applyMockAuthInterface(client, rejectRefreshAccessToken);
+    client.isAuthUrl.mockReturnValue(true);
+    client.getDecodedAccessToken.mockReturnValue({});
+    client.isAccessTokenExpired.mockReturnValue(true);
+    // eslint-disable-next-line no-underscore-dangle
+    axiosConfig.__Rewire__('queueRequests', false);
+    const failedResult = client.interceptors.request.handlers[0].fulfilled({});
+
+    failedResult.catch(() => {
+      expect(client.logout).toHaveBeenCalled();
+    });
+  });
+
+
 });
 
 describe('AuthenticatedAPIClient ensureCsrfToken request interceptor', () => {
@@ -338,8 +378,9 @@ describe('AuthenticatedAPIClient ensureCsrfToken request interceptor', () => {
 describe('AuthenticatedAPIClient response interceptor', () => {
   const data = 'Response data';
   const request = { url: 'https://example.com' };
+  const accessTokenRefreshRequest = { url: authConfig.refreshAccessTokenEndpoint };
   [
-    [{ response: { status: 401, data }, request, message: 'Failed' }, expectLogoutToHaveBeenCalled],
+    [{ response: { status: 401, data }, request, message: 'Failed' }, expectLogoutToNotHaveBeenCalled],
     [{ response: {} }, expectLogoutToNotHaveBeenCalled],
     [{ request }, expectLogoutToNotHaveBeenCalled],
     [{}, expectLogoutToNotHaveBeenCalled],
@@ -347,9 +388,32 @@ describe('AuthenticatedAPIClient response interceptor', () => {
     testResponseInterceptorRejection(...mockValues);
   });
 
+  // it('redirects to login if a token refresh fails', () => {
+  //   const client = getAuthenticatedAPIClient(authConfig);
+  //   const reponse = {
+  //     response: { status: 401, data },
+  //     request: { url: refreshAccessTokenEndpoint },
+  //   };
+  //   const response = { data: 'It worked!' };
+  //   const result = client.interceptors.response.handlers[0].fulfilled(response);
+  //   expect(result).toBe(response);
+  // });
+
+  // const clientA = getAuthenticatedAPIClient(authConfig);
+  // applyMockAuthInterface(clientA);
+  // expectLogoutToNotHaveBeenCalled(client);
+  // client.logout();
+  // expectLogoutToHaveBeenCalled(client);
+
   it('returns response if it is fulfilled', () => {
     const client = getAuthenticatedAPIClient(authConfig);
     const response = { data: 'It worked!' };
+    const result = client.interceptors.response.handlers[0].fulfilled(response);
+    expect(result).toBe(response);
+  });
+  it('returns response if it is rejected', () => {
+    const client = getAuthenticatedAPIClient(authConfig);
+    const response = { response: { status: 401, data }, request, message: 'Failed' };
     const result = client.interceptors.response.handlers[0].fulfilled(response);
     expect(result).toBe(response);
   });

--- a/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
+++ b/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
@@ -360,6 +360,36 @@ describe('AuthenticatedAPIClient ensureCsrfToken request interceptor', () => {
 });
 
 describe('AuthenticatedAPIClient response interceptor', () => {
+  it('returns error if it fails with 401', () => {
+    const client = getAuthenticatedAPIClient(authConfig);
+    const errorResponse = { response: { status: 401, data: 'it failed' } };
+    client.interceptors.response.handlers[0].rejected(errorResponse)
+      .catch((promiseError) => {
+        expect(promiseError).toBe(errorResponse);
+      });
+  });
+  it('returns error if token refresh fails with 401', () => {
+    const client = getAuthenticatedAPIClient(authConfig);
+    const errorResponse = {
+      response: {
+        status: 401,
+        data: 'it failed',
+        config: { url: authConfig.refreshAccessTokenEndpoint },
+      },
+    };
+    client.interceptors.response.handlers[0].rejected(errorResponse)
+      .catch((promiseError) => {
+        expect(promiseError).toBe(errorResponse);
+      });
+  });
+  it('returns error if it fails with 403', () => {
+    const client = getAuthenticatedAPIClient(authConfig);
+    const errorResponse = { response: { status: 403, data: 'it failed' } };
+    client.interceptors.response.handlers[0].rejected(errorResponse)
+      .catch((promiseError) => {
+        expect(promiseError).toBe(errorResponse);
+      });
+  });
   it('returns response if it is fulfilled', () => {
     const client = getAuthenticatedAPIClient(authConfig);
     const response = { data: 'It worked!' };

--- a/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
+++ b/src/AuthenticatedAPIClient/tests/AuthenticatedAPIClient.test.jsx
@@ -70,6 +70,7 @@ function testJwtCookieInterceptorFulfillment(
   rejectRefreshAccessToken,
   expects,
 ) {
+  // eslint-disable-next-line consistent-return
   it(`${expects.name} when isAuthUrl=${isAuthUrl} mockAccessToken=${mockAccessToken} isAccessTokenExpired=${isAccessTokenExpired}`, () => {
     const client = getAuthenticatedAPIClient(authConfig);
     applyMockAuthInterface(client, rejectRefreshAccessToken);
@@ -82,9 +83,12 @@ function testJwtCookieInterceptorFulfillment(
     expects(client);
 
     if (rejectRefreshAccessToken) {
-      fulfilledResult.catch(() => {
+      return fulfilledResult.catch(() => {
         expect(client.logout).toHaveBeenCalled();
       });
+    } else { // eslint-disable-line no-else-return
+      expect(client.logout).not.toHaveBeenCalled();
+      expect(fulfilledResult).toBeInstanceOf(Object); // from above: fullfilled({})
     }
   });
 }


### PR DESCRIPTION
No redirects will happen for API calls that are not access token refreshes.

Adds a callback for when a login refresh fails. 

- If no `handleRefreshAccessTokenFailure` is supplied in the config, it will logout and redirect.
- If a `handleRefreshAccessTokenFailure` is supplied and executing that function `handleRefreshAccessTokenFailure(error)` returns a falsey value, it will not logout or redirect.
- If a `handleRefreshAccessTokenFailure` is supplied and it returns true, it will logout and redirect.