### PR TITLE
ARCH-948: fix: refactor ensurePublicOrAuthenticationAndCookies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,18 @@
                     "**/*.test.js"
                 ]
             }
+        ],
+        "max-len": [
+          "error",
+          120,
+          2,
+          {
+            "ignoreUrls": true,
+            "ignoreComments": false,
+            "ignoreRegExpLiterals": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true
+          }
         ]
     },
     "env": {

--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,13 @@ To install frontend-auth into your project:
      // handleRefreshAccessTokenFailure: error => {},
    });
 
-   apiClient.ensurePublicOrAuthenticationAndCookies(window.location.pathname).then((accessToken) => {
-     // A non-null accessToken here indicates that the user is authenticated and the apiClient is ready to be used.
-
-     // NOTE: There is a bug where the accessToken occasionally comes back blank.  See https://openedx.atlassian.net/browse/ARCH-948 for more details.
-   });
+   apiClient.ensureAuthenticatedUser(window.location.pathname)
+     .then(({ authenticatedUser, decodedAccessToken }) => {
+        // 1. Successfully resolving the promise means that the user is authenticated and the apiClient is ready to be used.
+        // 2. ``authenticatedUser`` is an object containing user account data that was stored in the access token.
+        // 3. You probably won't need ``decodedAccessToken``, but it is included for completeness and is the raw version
+        //    of the data used to create ``authenticatedUser``.
+     });
 
 ``frontend-auth`` provides a ``PrivateRoute`` component which can be used along with ``react-router`` to require authentication for specific routes in your app. Here is an example of defining a route that requires authentication:
 

--- a/src/tests/setupTest.js
+++ b/src/tests/setupTest.js
@@ -6,7 +6,7 @@ Enzyme.configure({ adapter: new Adapter() });
 process.env.BASE_URL = 'http://example.com';
 process.env.LMS_BASE_URL = 'http://auth.example.com';
 process.env.LOGIN_URL = 'http://auth.example.com/login';
-process.env.LOGIN_URL = 'http://auth.example.com/logout';
+process.env.LOGOUT_URL = 'http://auth.example.com/logout';
 process.env.REFRESH_ACCESS_TOKEN_ENDPOINT = 'http://auth.example.com/api/refreshToken';
 process.env.ACCESS_TOKEN_COOKIE_NAME = 'access-token-cookie-name';
 process.env.USER_INFO_COOKIE_NAME = 'user-info-cookie-name';


### PR DESCRIPTION
**fix: refactor ensurePublicOrAuthenticationAndCookies**

- Protects user against an infinite redirect to login
- Refactors ensurePublicOrAuthenticationAndCookies with the
below breaking changes.

BREAKING CHANGE: The refactor has the following breaking changes:

- Renamed ensurePublicOrAuthenticationAndCookies to
ensureAuthenticatedUser.
- Removed the capability to handle public routes in
ensureAuthenticatedUser.  Just don't call it.
- Removed getAuthenticationState() function which was unreliable,
because it used the cookie which could have expired since it was tested.
Instead, use the new response sent to the ensureAuthenticatedUser
promise (see below).
- Removed the deprecated callback.  Just use the promise instead.

The promise is now resolved with an object of the form:
{
  authenticatedUser: {...},
  decodedAccessToken: {...},
}

ARCH-948