### PR TITLE
fix: clean-up research for null refresh token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ To install frontend-auth into your project:
         // 2. ``authenticatedUser`` is an object containing user account data that was stored in the access token.
         // 3. You probably won't need ``decodedAccessToken``, but it is included for completeness and is the raw version
         //    of the data used to create ``authenticatedUser``.
+     })
+     .catch(e => {
+       // throw or handle error
      });
 
 ``frontend-auth`` provides a ``PrivateRoute`` component which can be used along with ``react-router`` to require authentication for specific routes in your app. Here is an example of defining a route that requires authentication:

--- a/src/AuthenticatedAPIClient/authInterface.js
+++ b/src/AuthenticatedAPIClient/authInterface.js
@@ -69,20 +69,11 @@ export default function applyAuthInterface(httpClient, authConfig) {
             const refreshedAccessToken = httpClient.getDecodedAccessToken();
 
             if (refreshedAccessToken === null) {
-              // TODO: ARCH-948: This should never happen, but it does. Researching...
+              // This should never happen, but it does. See ARCH-948 for past research into why.
               const errorMessage = 'Access token is null after supposedly successful refresh.';
-              const cookieFound = global.document.cookie
-                .includes(httpClient.accessTokenCookieName);
-              const cookieEnabledIsDefined = global.navigator &&
-                global.navigator.cookieEnabled !== undefined;
-              const cookieDisabled = cookieEnabledIsDefined && !global.navigator.cookieEnabled;
-              // Logging as error over info to simplify search for root problem.
               httpClient.loggingService.logError(`frontend-auth: ${errorMessage}`, {
                 previousAccessToken: accessToken,
                 axiosResponse: response,
-                cookieEnabledIsDefined,
-                cookieDisabled,
-                cookieFound,
               });
               reject(new Error(errorMessage));
               return;


### PR DESCRIPTION
- removes some NewRelic custom metrics that are no longer of use.
- update README to include note about throwing errors.

ARCH-948