### PR TITLE
feat: simplify access token refresh queuing

### DIFF
--- a/src/AuthenticatedAPIClient/authInterface.js
+++ b/src/AuthenticatedAPIClient/authInterface.js
@@ -99,6 +99,9 @@ export default function applyAuthInterface(httpClient, authConfig) {
   httpClient.refreshAccessTokenPromise = null;
 
   httpClient.refreshAccessTokenOnce = () => {
+    // We have found that results from multiple calls to getDecodedAccessToken
+    // may change between calls. We should reduce calls to getDecodedAccessToken
+    // as much as possible.
     const decodedAccessToken = httpClient.getDecodedAccessToken();
     if (!httpClient.isAccessTokenExpired(decodedAccessToken)) {
       // The token is valid. Carry on.

--- a/src/AuthenticatedAPIClient/authInterface.js
+++ b/src/AuthenticatedAPIClient/authInterface.js
@@ -73,7 +73,8 @@ export default function applyAuthInterface(httpClient, authConfig) {
     })
     .catch(() => {
       const isRedirectFromLoginPage = global.document.referrer &&
-      global.document.referrer.startsWith(httpClient.loginUrl);
+        global.document.referrer.startsWith(httpClient.loginUrl);
+
       if (isRedirectFromLoginPage) {
         throw new Error('Redirect from login page. Rejecting to avoid infinite redirect loop.');
       }
@@ -98,9 +99,10 @@ export default function applyAuthInterface(httpClient, authConfig) {
   httpClient.refreshAccessTokenPromise = null;
 
   httpClient.refreshAccessTokenOnce = () => {
-    if (!httpClient.isAccessTokenExpired(httpClient.getDecodedAccessToken())) {
+    const decodedAccessToken = httpClient.getDecodedAccessToken();
+    if (!httpClient.isAccessTokenExpired(decodedAccessToken)) {
       // The token is valid. Carry on.
-      return Promise.resolve(httpClient.getDecodedAccessToken());
+      return Promise.resolve(decodedAccessToken);
     }
 
     if (httpClient.refreshAccessTokenPromise === null) {

--- a/src/AuthenticatedAPIClient/axiosConfig.js
+++ b/src/AuthenticatedAPIClient/axiosConfig.js
@@ -56,13 +56,13 @@ function applyAxiosInterceptors(authenticatedAPIClient) {
     return request;
   }
 
-  function ensureValidJWTCookie(requestConfig) {
-    // if we've got what we need
-    if (authenticatedAPIClient.isAuthUrl(requestConfig.url)) {
-      return requestConfig;
+  function ensureValidJWTCookie(axiosRequestConfig) {
+    const jwtIsNotRequired = authenticatedAPIClient.isAuthUrl(axiosRequestConfig.url);
+    if (jwtIsNotRequired) {
+      return axiosRequestConfig;
     }
 
-    return authenticatedAPIClient.refreshAccessTokenOnce().then(() => requestConfig);
+    return authenticatedAPIClient.refreshAccessTokenOnce().then(() => axiosRequestConfig);
   }
 
   // Log errors and info for unauthorized API responses


### PR DESCRIPTION
Simplify access token refresh mechanism. It now leverages promises only to achieve a queuing effect when refreshing a token. `ensureAuthenticatedUser` now leverages this queuing instead of having its own refresh implementation.

By pushing all the promises and queuing into httpClient, we take a step toward consolidating the location of accessToken logic and simplifying our axios interceptors.

This is the first of a few PRs I intend to make:
- a similar refactor for the csrf token refresh
- breaking access token logic out away from inside the httpClient
- breaking out csrf token logic to its own location
- creating an authenticated and unauthenticated axios export.